### PR TITLE
feat: GitHub Pages auto-deploy from release (pnpm, Vite base, SPA 404)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,60 @@
+name: Deploy to GitHub Pages
+on:
+  push:
+    branches: [ release ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Node 最新 & pnpm セットアップ（corepack経由）
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 'latest'
+          cache: 'pnpm'
+
+      - name: Enable corepack & set pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@latest --activate
+          pnpm --version
+
+      - name: Install deps (pnpm, frozen lockfile)
+        run: pnpm install --frozen-lockfile
+
+      # Vite の base を自動で渡したい場合は環境変数を設定
+      - name: Build
+        env:
+          VITE_BASE: "/${{ github.event.repository.name }}/"
+        run: |
+          pnpm build
+
+      - name: Copy SPA 404 (use built index.html)
+        run: |
+          cp dist/index.html dist/404.html
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ${{ vars.DIST_DIR || 'dist' }}
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# JSON Diff Viewer
+
+公開URL（GitHub Pages）
+
+- https://ichien178.github.io/json-diff-viewer/
+
+ローカル開発
+
+```bash
+pnpm i
+pnpm dev
+```
+
+デプロイ方法
+
+- `release` ブランチにマージ/プッシュすると自動ビルド・公開されます（GitHub Actions + Pages）
+
+注意点
+
+- Vite の `base` は CI 時のみ `/${REPO_NAME}/` が適用されます（`vite.config.ts`）。ローカルでは `/` のままです。
+- SPA の 404 対策として `public/404.html` を配置しています（Pages の直接アクセス対策）。
+- リポジトリの Settings > Pages で Build and deployment を GitHub Actions に設定してください（UI 操作）。

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>JSON Diff Viewer</title>
+    <style>
+      :root { color-scheme: light dark; }
+      body { margin: 0; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji"; }
+      header { padding: 12px 16px; border-bottom: 1px solid #ddd; }
+      main { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; padding: 12px; }
+      .column { display: flex; flex-direction: column; gap: 8px; }
+      textarea { width: 100%; height: 40vh; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; font-size: 13px; padding: 8px; box-sizing: border-box; }
+      .controls { display: flex; gap: 8px; padding: 8px 12px; align-items: center; }
+      .controls button { padding: 6px 10px; }
+      .output { grid-column: 1 / -1; white-space: pre-wrap; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; border-top: 1px solid #ddd; padding: 12px; }
+      .line { display: block; padding: 2px 6px; border-left: 4px solid transparent; }
+      .add { background: #e6ffed; color: #03543f; border-left-color: #059669; }
+      .remove { background: #ffebeb; color: #9b1c1c; border-left-color: #dc2626; }
+      .unchanged { color: inherit; opacity: 0.85; }
+      .error { color: #b91c1c; }
+      label { font-size: 12px; opacity: 0.8; }
+      .row { display: flex; gap: 12px; align-items: center; }
+      .row > * { flex: 1; }
+      .small { font-size: 12px; opacity: 0.8; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,10 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+const repoBase = process.env.VITE_BASE || '/';
+
 export default defineConfig({
   plugins: [react()],
+  // Use repo base path on CI (GitHub Pages), keep '/' locally for dev
+  base: process.env.CI ? repoBase : '/',
 });


### PR DESCRIPTION
## Summary
- Set up GitHub Actions to build on release branch and deploy to GitHub Pages
- Node latest via actions/setup-node; pnpm via corepack, frozen lockfile
- Vite base set to repo path in CI via VITE_BASE env
- SPA 404 fallback added (public/404.html and artifact copy)
- README updated with URL and ops notes

## Details
- Workflow: .github/workflows/deploy.yml
- Build: pnpm build; artifact from dist
- Deploy: actions/deploy-pages@v4
- Base: vite.config.ts uses process.env.CI ? VITE_BASE : '/'

## Ops
- Ensure Settings > Pages > Build and deployment is set to GitHub Actions
- Deploys at https://ichien178.github.io/json-diff-viewer/

## Checklist
- [x] pnpm build succeeds locally
- [x] Vite base configured for Pages subpath
- [x] SPA deep link handled via 404.html
- [x] Minimal changes; conventional commit message
